### PR TITLE
Use ignore package in  copy workflow

### DIFF
--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -2,6 +2,8 @@
  * https://github.com/gruntjs/grunt-contrib-copy
  */
 
+var ignore = require('ignore');
+
 module.exports = function (grunt, options) {
 	return {
 		deploy: {
@@ -10,26 +12,19 @@ module.exports = function (grunt, options) {
 				dest: 'dist/',
 				filter: function (filepath) {
 					var unixifyPath = function (filepath) {
-
 						var isWindows = process.platform === 'win32';
-						if (isWindows) {
-							return filepath.replace(/\\/g, '/');
-						} else {
-							return filepath;
-						}
+						return isWindows ? filepath.replace(/\\/g, '/') : filepath;
 					};
+
 					filepath = unixifyPath(filepath);
-					var exclude = grunt.file.read('.distignore');
-					var cwd = grunt.file.read('.distignore').split(/\r|\n/);
-					cwd = cwd.filter(function (e) {
-						return e
-					});
-					for (index in cwd) {
-						var file = cwd[index];
-						if (filepath.indexOf(file) === 0) {
-							return false;
-						}
+
+					var distignore = grunt.file.read('.distignore').split(/\r|\n/);
+					var ig = ignore().add( distignore );
+
+					if ( ig.ignores( filepath ) ) {
+						return false;
 					}
+
 					return true;
 				}
 			}]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "autoprefixer": "^9.0.0",
     "grunt": "~1.0.0",
+    "grunt-cachebuster": "^0.1.7",
     "grunt-checktextdomain": "^1.0.1",
+    "grunt-contrib-compress": "^1.4.1",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-imagemin": "^3.0.0",
     "grunt-contrib-jshint": "^2.0.0",
     "grunt-contrib-watch": "^1.0.0",
@@ -21,18 +24,16 @@
     "grunt-phpcbf": "^0.1.0",
     "grunt-phpcs": "^0.4.0",
     "grunt-phplint": "0.1.0",
+    "grunt-phpunit": "^0.3.6",
     "grunt-postcss": "^0.9.0",
+    "grunt-rsync": "^3.0.0",
     "grunt-sync": "^0.8.0",
     "grunt-text-replace": "^0.4.0",
+    "grunt-version": "1.x",
     "grunt-wp-css": "^0.2.1",
     "grunt-wp-i18n": "^1.0.0",
-    "grunt-version": "1.x",
-    "time-grunt": "^1.4.0",
-    "grunt-contrib-compress": "^1.4.1",
-    "grunt-phpunit": "^0.3.6",
-    "grunt-contrib-copy": "^1.0.0",
     "grunt-wp-readme-to-markdown": "^2.0.1",
-    "grunt-rsync": "^3.0.0",
-    "grunt-cachebuster": "^0.1.7"
+    "ignore": "^5.1.0",
+    "time-grunt": "^1.4.0"
   }
 }


### PR DESCRIPTION
Using ignore package, now copy task will make distignore work similar to how gitignore works. Closes https://github.com/Codeinwp/grunt-plugin-fleet/issues/12

@selul Can you or someone test this to make sure it works everywhere? We also need test tested on a Windows.